### PR TITLE
Added timeout

### DIFF
--- a/panoramix.py
+++ b/panoramix.py
@@ -46,6 +46,11 @@ elif "--errors" in sys.argv:
 else:
     log_level = logging.INFO
 
+if "--timeout" in sys.argv:
+    timeout = int(sys.argv[sys.argv.index("--timeout") + 1])
+else:
+    timeout = 120
+
 logging.getLogger("pano.matcher").setLevel(logging.INFO)
 
 coloredlogs.install(
@@ -226,7 +231,7 @@ def decompile(this_addr, only_func_name=None):
             if target > 1 and loader.lines[target][1] == "jumpdest":
                 target += 1
 
-            @timeout_decorator.timeout(120, use_signals=True)
+            @timeout_decorator.timeout(timeout, use_signals=True)
             def dec():
                 trace = VM(loader).run(target, stack=stack)
                 explain("Initial decompiled trace", trace[1:])

--- a/panoramix.py
+++ b/panoramix.py
@@ -46,11 +46,6 @@ elif "--errors" in sys.argv:
 else:
     log_level = logging.INFO
 
-if "--timeout" in sys.argv:
-    timeout = int(sys.argv[sys.argv.index("--timeout") + 1])
-else:
-    timeout = 120
-
 logging.getLogger("pano.matcher").setLevel(logging.INFO)
 
 coloredlogs.install(
@@ -59,6 +54,11 @@ coloredlogs.install(
     datefmt="%H:%M:%S",
     field_styles={"asctime": {"color": "white", "faint": True}},
 )
+
+if "--timeout" in sys.argv:
+    timeout = int(sys.argv[sys.argv.index("--timeout") + 1])
+else:
+    timeout = 120
 
 
 VER = "17 Feb 2020"


### PR DESCRIPTION
Added timeout as cli argument `--timeout`

Some contracts needed more than 2 minutes to decompile.

See also - https://github.com/eveem-org/panoramix/pull/51 (But I feel it won't go in there soon)